### PR TITLE
Fix autocmd

### DIFF
--- a/plugin/goimports.vim
+++ b/plugin/goimports.vim
@@ -1,10 +1,10 @@
 function! s:install()
   augroup goimports_autoformat
-    au!
+    au! * <buffer>
     autocmd BufWritePre <buffer> call goimports#Run()
-    command! -buffer -nargs=1 -bang -complete=customlist,goimports#Complete GoImport call goimports#SwitchImport(1, '', <f-args>, '<bang>')
-    command! -buffer -nargs=* -bang -complete=customlist,goimports#Complete GoImportAs call goimports#SwitchImport(1, '', <f-args>, '<bang>')
   augroup END
+  command! -buffer -nargs=1 -bang -complete=customlist,goimports#Complete GoImport call goimports#SwitchImport(1, '', <f-args>, '<bang>')
+  command! -buffer -nargs=* -bang -complete=customlist,goimports#Complete GoImportAs call goimports#SwitchImport(1, '', <f-args>, '<bang>')
 endfunction
 
 augroup goimports_install


### PR DESCRIPTION
`au!` must be replace by `au! * <buffer>`, because `au!` removes all `BufWritePre` autocmds including other buffers.

It can be reproduced by:

```
:e a.go
:e b.go
:e a.go
```

Then autocmd in a.go disappears.