### PR TITLE
enable/disable switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ For [vim-plug](https://github.com/junegunn/vim-plug) plugin manager:
 Plug 'mattn/vim-goimports'
 ```
 
+## Configuration
+
+```viml
+" enable (default)
+let g:goimports = 1
+" disable
+let g:goimports = 0
+```
+
 ## Requirements
 
 * goimports

--- a/autoload/goimports.vim
+++ b/autoload/goimports.vim
@@ -1,6 +1,9 @@
 " vint: -ProhibitUnusedVariable
 
 function! goimports#Run() abort
+  if !get(g:, 'goimports', 1)
+    return
+  endif
   if !executable('goimports')
     call s:error('goimports executable not found')
     return


### PR DESCRIPTION
Occasionally `goimports` is slow in case you have a lot of Go project under GOPATH. I'd like to switch the feature between enable and disable. How about this?