### PR TITLE
Add :GoImportRun

### DIFF
--- a/plugin/goimports.vim
+++ b/plugin/goimports.vim
@@ -5,6 +5,7 @@ function! s:install()
   augroup END
   command! -buffer -nargs=1 -bang -complete=customlist,goimports#Complete GoImport call goimports#SwitchImport(1, '', <f-args>, '<bang>')
   command! -buffer -nargs=* -bang -complete=customlist,goimports#Complete GoImportAs call goimports#SwitchImport(1, <f-args>, '<bang>')
+  command! -buffer -bang GoImportRun call goimports#Run()
 endfunction
 
 augroup goimports_install


### PR DESCRIPTION
Sometimes I write code snippets in unnamed buffer.  In this case, I want to run vim-goimports without saving.
I can run it just call `goimports#Run()`, however Ex command is more useful.