### PR TITLE
make GoImportRun ignores `g:goimports=0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Plug 'mattn/vim-goimports'
 ## Configuration
 
 ```viml
-" enable (default)
+" enable auto format when write (default)
 let g:goimports = 1
-" disable
+" disable auto format. but :GoImportRun will work.
 let g:goimports = 0
 ```
 

--- a/autoload/goimports.vim
+++ b/autoload/goimports.vim
@@ -1,9 +1,13 @@
 " vint: -ProhibitUnusedVariable
 
-function! goimports#Run() abort
+function! goimports#AutoRun() abort
   if !get(g:, 'goimports', 1)
     return
   endif
+  call goimports#Run()
+endfunction
+
+function! goimports#Run() abort
   if !executable('goimports')
     call s:error('goimports executable not found')
     return

--- a/plugin/goimports.vim
+++ b/plugin/goimports.vim
@@ -1,7 +1,7 @@
 function! s:install()
   augroup goimports_autoformat
     au! * <buffer>
-    autocmd BufWritePre <buffer> call goimports#Run()
+    autocmd BufWritePre <buffer> call goimports#AutoRun()
   augroup END
   command! -buffer -nargs=1 -bang -complete=customlist,goimports#Complete GoImport call goimports#SwitchImport(1, '', <f-args>, '<bang>')
   command! -buffer -nargs=* -bang -complete=customlist,goimports#Complete GoImportAs call goimports#SwitchImport(1, <f-args>, '<bang>')


### PR DESCRIPTION
`let g:goimports=0` を設定していると `:GoImportRun` コマンドも動きませんでした。
明示的に実行しているのだから設定の有無にかかわらず動いて欲しいと考えました。