### PR TITLE
don't append CRs for goimports

### DIFF
--- a/autoload/goimports.vim
+++ b/autoload/goimports.vim
@@ -139,9 +139,7 @@ function! s:getlines()
   if &l:endofline || (&l:fixendofline && !&l:binary)
     call add(l:buf, '')
   endif
-  if &l:fileformat ==# 'dos'
-    call map(l:buf, 'v:val."\r"')
-  endif
+  " goimports assumes source file have LF only as EOL
   return l:buf
 endfunction
 


### PR DESCRIPTION
goimports に渡すソースが CRLF を行末記号にしていると
goimports はファイル全体の行末を LF に置き換える diff を吐く。
vim-goimports はそのdiff を正しく解釈できずに
行頭の package main などを消してしまう。

本来goのファイルは ff=unix でソースを書くべきだが
プラグインとしてはとりあえず CR を付けないようにすることで回避できるので
そうしておく。

---

発端

https://vim-jp.slack.com/archives/CJMV3MSLR/p1593711231177500

> すみません質問なのですが、以下のようなGoのコードを書いて保存すると、package の行が削除されてしまうようでして、何か回避策があるのかお伺いしたいのです。
>
> ```go
> package main
> func main() {
> 	fmt.Println("test")
> }
> ```
>
>↑このようなコードを作成して保存すると、↓のようなコードに整形されます。
>
> ```go
> import "fmt"
> func main() {
> 	fmt.Println("test")
> }
> ```
>
> 私のほうでも少しだけ調べてみたのですが、https://github.com/mattn/vim-goimports/blob/master/autoload/goimports.vim#L140 をコメントアウトすると package も削除されず import も挿入されました。