### PR TITLE
support alternative tool (e.g. gofumpt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ let g:goimports = 0
     let g:goimports_local = 'github.com/myrepo'
     ```
 
+* To replace goimports command with the drop in replacement tool (e.g. [gofumpt](https://github.com/mvdan/gofumpt)).
+
+  ```viml
+  " goimport (default)
+  let g:goimports_cmd = 'goimports'
+  let g:goimports_simplify_cmd = 'gofmt'
+  
+  " gofumpt
+  let g:goimports_cmd = 'gofumports'
+  let g:goimports_simplify_cmd = 'gofumpt'
+  ```
+
 ## Requirements
 
 * goimports

--- a/autoload/goimports.vim
+++ b/autoload/goimports.vim
@@ -1,5 +1,15 @@
 " vint: -ProhibitUnusedVariable
 
+let s:goimports_cmd = 'goimports'
+if exists('g:goimports_cmd')
+  let s:goimports_cmd = g:goimports_cmd
+endif
+
+let s:goimports_simplify_cmd = 'gofmt'
+if exists('g:goimports_simplify_cmd')
+  let s:goimports_simplify_cmd = g:goimports_simplify_cmd
+endif
+
 function! goimports#AutoRun() abort
   if !get(g:, 'goimports', 1)
     return
@@ -64,7 +74,7 @@ else
 endif
 
 function! goimports#Run() abort
-  if !executable('goimports')
+  if !executable(s:goimports_cmd)
     call s:error('goimports executable not found')
     return
   endif
@@ -98,7 +108,7 @@ endfunction
 
 function! s:goimports()
   let l:file = expand('%')
-  let l:cmd = printf('goimports -d -srcdir %s', shellescape(l:file))
+  let l:cmd = printf('%s -d -srcdir %s', s:goimports_cmd, shellescape(l:file))
   let l:local = get(g:, 'goimports_local', '')
   if l:local != ''
     let l:cmd .= printf(' -local "%s"', l:local)
@@ -110,7 +120,8 @@ endfunction
 
 function! s:gofmt_s()
   let l:file = expand('%')
-  let l:out = system('gofmt -s -d', join(s:getlines(), "\n"))
+  let l:cmd = printf('%s -s -d', s:goimports_simplify_cmd)
+  let l:out = system(l:cmd, join(s:getlines(), "\n"))
   let l:err = v:shell_error
   return [l:out, l:err]
 endfunction


### PR DESCRIPTION
## Description
Add `g:goimports_cmd` and `g:goimports_simplify_cmd` to use the drop in replacement tool of goimports (e.g. [gofumpt](https://github.com/mvdan/gofumpt)).
